### PR TITLE
Update stress-ng to 0.13.05 and fix source URL

### DIFF
--- a/recipes-test/stress-ng/stress-ng_0.13.05.bb
+++ b/recipes-test/stress-ng/stress-ng_0.13.05.bb
@@ -5,10 +5,10 @@ HOMEPAGE = "https://kernel.ubuntu.com/~cking/stress-ng/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "https://kernel.ubuntu.com/~cking/tarballs/${BPN}/${BP}.tar.xz \
+SRC_URI = "http://ftp.debian.org/debian/pool/main/s/stress-ng/stress-ng_${PV}.orig.tar.xz \
            file://0001-Do-not-preserve-ownership-when-installing-example-jo.patch \
            "
-SRC_URI[sha256sum] = "f37f739e4d15343360a47980b67dc8b2a6bf3d4d3ef727d55e2dd99a0b64f9ea"
+SRC_URI[sha256sum] = "f058c8fba37596ab32c3a4b2aedbdbf5f2b8a8ba1d312059e733290543ad00ac"
 
 DEPENDS = "coreutils-native zlib libaio libbsd attr libcap libgcrypt keyutils lksctp-tools"
 


### PR DESCRIPTION
The developer of stress-ng has left Canonical, and the project
has moved to github. This currently makes the bitbake fail.
However, the releases there are not drop in replacements 
for the old release tarballs. So I decided to pull a patch 
release newer version from the debian archive of the
original source instead to get the build working again.

I admit that this a bit of a hack, but I'm not familiar
enough with bitbake to make a tagged pull from github work
correctly after a few attempts.

For reference, the new home of the project is:
https://github.com/ColinIanKing/stress-ng