### PR TITLE
meta-sifive: Kernel upgrade to 6.12

### DIFF
--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0001-platform-Add-ESWIN-EIC770x-platform.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0001-platform-Add-ESWIN-EIC770x-platform.patch
@@ -1,7 +1,7 @@
-From 0d7141a6195824103a6a029f289459cb86f164d7 Mon Sep 17 00:00:00 2001
+From 518b40534155a6632061630a4972cdfda999a427 Mon Sep 17 00:00:00 2001
 From: Darshan Prajapati <darshan.prajapati@einfochips.com>
 Date: Wed, 5 Jun 2024 11:45:33 +0530
-Subject: [PATCH 1/6] platform: Add ESWIN EIC770x platform
+Subject: [PATCH 1/7] platform: Add ESWIN EIC770x platform
 
 - ESWIN EIC770x is a 64-bit RISC-V core.
 - Write Fractional register to ensure correct baud rate

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0002-platform-eswin-Add-EIC770x-UART-driver.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0002-platform-eswin-Add-EIC770x-UART-driver.patch
@@ -1,7 +1,7 @@
-From 8a80f00208397ecb26a1d7f4f638fff7997c4234 Mon Sep 17 00:00:00 2001
+From fb3877a0076fb7257b1884a5e9a2235de26a630c Mon Sep 17 00:00:00 2001
 From: Pritesh Patel <pritesh.patel@einfochips.com>
 Date: Tue, 20 May 2025 10:03:40 +0000
-Subject: [PATCH 2/6] platform: eswin: Add EIC770x UART driver
+Subject: [PATCH 2/7] platform: eswin: Add EIC770x UART driver
 
 Add UART driver for communication with MCU
 

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0003-platform-eswin-Add-shutdown-and-reset-function.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0003-platform-eswin-Add-shutdown-and-reset-function.patch
@@ -1,7 +1,7 @@
-From 50d2aeb426f91af9b73486b451cdeea5d1f3af73 Mon Sep 17 00:00:00 2001
+From dc5c62ab2b0e61466f73a48aac53813907c4fec4 Mon Sep 17 00:00:00 2001
 From: Pritesh Patel <pritesh.patel@einfochips.com>
 Date: Tue, 20 May 2025 10:05:21 +0000
-Subject: [PATCH 3/6] platform: eswin: Add shutdown and reset function
+Subject: [PATCH 3/7] platform: eswin: Add shutdown and reset function
 
 Send message to MCU via UART2 for shutdown and reset function of SoC.
 

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0004-lib-sbi-Configure-CSR-registers.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0004-lib-sbi-Configure-CSR-registers.patch
@@ -1,7 +1,7 @@
-From fde4c25677f1fb177c0277033e39c5ed27a735e9 Mon Sep 17 00:00:00 2001
+From c0a5814db4c6f59bbfe28c19b783af6d6247e69e Mon Sep 17 00:00:00 2001
 From: Pritesh Patel <pritesh.patel@einfochips.com>
 Date: Mon, 19 May 2025 14:50:02 +0000
-Subject: [PATCH 4/6] lib: sbi: Configure CSR registers
+Subject: [PATCH 4/7] lib: sbi: Configure CSR registers
 
 Configure CSR with below values values
 0x7C1 --> 0x4000

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0005-lib-sbi-eic770x-Add-PMP-for-TOR-region.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0005-lib-sbi-eic770x-Add-PMP-for-TOR-region.patch
@@ -1,7 +1,7 @@
-From b684f521a7921ad823fc6f2657890bc887aadc6c Mon Sep 17 00:00:00 2001
+From 4d39356db6d4474adfad29b4a926423542b4338c Mon Sep 17 00:00:00 2001
 From: Pritesh Patel <pritesh.patel@einfochips.com>
 Date: Mon, 19 May 2025 14:52:01 +0000
-Subject: [PATCH 5/6] lib: sbi: eic770x: Add PMP for TOR region
+Subject: [PATCH 5/7] lib: sbi: eic770x: Add PMP for TOR region
 
 - Modify pmpcfg csr if TOR size is defined
 - Added 'unsigned long tor' in sbi_domain_memregion_init

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0006-sbi-init-Modify-CSR-registers.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0006-sbi-init-Modify-CSR-registers.patch
@@ -1,7 +1,7 @@
-From 1d3cee822a66d1201cdb51df0df4277a4cd7be47 Mon Sep 17 00:00:00 2001
+From a450510a19a4b7d380c0a950172b7a5a25109d68 Mon Sep 17 00:00:00 2001
 From: Pinkesh Vaghela <pinkesh.vaghela@einfochips.com>
 Date: Fri, 6 Jun 2025 13:04:15 +0530
-Subject: [PATCH 6/6] sbi: init: Modify CSR registers
+Subject: [PATCH 6/7] sbi: init: Modify CSR registers
 
 Changed CSR 0x7C3 and 0x7C4 values to improve DDR preformance
   0x7C3 --> 0x104095c1be241

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0007-lib-Emulate-HENVCFG-and-SENVCFG-CSR-for-platforms-no.patch
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0007-lib-Emulate-HENVCFG-and-SENVCFG-CSR-for-platforms-no.patch
@@ -1,0 +1,49 @@
+From 6025600a80686868c5c1d658dabcb1d1cbd0f8ac Mon Sep 17 00:00:00 2001
+From: Jaychand Agrawal <jaychand.agrawal@einfochips.com>
+Date: Fri, 8 Aug 2025 12:24:39 +0530
+Subject: [PATCH 7/7] lib: Emulate HENVCFG and SENVCFG CSR for platforms not
+ having these CSR
+
+For platforms not having HENVCFG CSR, we trap-n-emulate HENVCFG CSR
+read/write in OpenSBI. Same rationale applies to SENVCFG CSR
+as well so we trap-n-emulate SENVCFG CSR for platforms not
+having SENVCFG CSR.
+
+Upstream-Status: Pending
+
+Signed-off-by: Jaychand Agrawal <jaychand.agrawal@einfochips.com>
+Co-developed-by: Pritesh Patel <pritesh.patel@einfochips.com>
+Signed-off-by: Pritesh Patel <pritesh.patel@einfochips.com>
+---
+ lib/sbi/sbi_emulate_csr.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lib/sbi/sbi_emulate_csr.c b/lib/sbi/sbi_emulate_csr.c
+index c2253c8..564a1f3 100644
+--- a/lib/sbi/sbi_emulate_csr.c
++++ b/lib/sbi/sbi_emulate_csr.c
+@@ -140,6 +140,10 @@ int sbi_emulate_csr_read(int csr_num, struct sbi_trap_regs *regs,
+ #undef switchcase_hpm_2
+ #undef switchcase_hpm
+ 
++	case CSR_HENVCFG:
++		break;
++	case CSR_SENVCFG:
++		break;
+ 	default:
+ 		ret = SBI_ENOTSUPP;
+ 		break;
+@@ -170,6 +174,10 @@ int sbi_emulate_csr_write(int csr_num, struct sbi_trap_regs *regs,
+ 			ret = SBI_ENOTSUPP;
+ 		break;
+ #endif
++	case CSR_HENVCFG:
++		break;
++	case CSR_SENVCFG:
++		break;
+ 	default:
+ 		ret = SBI_ENOTSUPP;
+ 		break;
+-- 
+2.25.1
+

--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.6.bb
+++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.6.bb
@@ -20,6 +20,7 @@ SRC_URI:append = " \
 	file://0004-lib-sbi-Configure-CSR-registers.patch \
 	file://0005-lib-sbi-eic770x-Add-PMP-for-TOR-region.patch \
 	file://0006-sbi-init-Modify-CSR-registers.patch \
+	file://0007-lib-Emulate-HENVCFG-and-SENVCFG-CSR-for-platforms-no.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux-sifive-hf-premier-p550_6.12.bb
+++ b/recipes-kernel/linux/linux-sifive-hf-premier-p550_6.12.bb
@@ -4,12 +4,12 @@ LICENSE = "GPL-2.0-only"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-KBRANCH ?= "rel/kernel/hifive-premier-p550"
-KBRANCH:hifive-premier-p550 = "rel/kernel/hifive-premier-p550"
+KBRANCH ?= "rel/kernel-6.12/hifive-premier-p550"
+KBRANCH:hifive-premier-p550 = "rel/kernel-6.12/hifive-premier-p550"
 
-SRCREV_machine ?= "b4a753400e624a0eba3ec475fba2866dd7efb767"
-SRCREV_machine:hifive-premier-p550 = "b4a753400e624a0eba3ec475fba2866dd7efb767"
-SRCREV_meta ?= "078f986aa4c328285abd0181cc21724d832a3ae0"
+SRCREV_machine ?= "c006f3bb3649056a32948c12e276932f30db459d"
+SRCREV_machine:hifive-premier-p550 = "c006f3bb3649056a32948c12e276932f30db459d"
+SRCREV_meta ?= "bc26c6c6b91fa0e4de4920544cc4aeeb3dedd894"
 
 KCONFIG_MODE = "--alldefconfig"
 
@@ -24,10 +24,10 @@ KERNEL_FEATURES:remove = "features/kernel-sample/kernel-sample.scc"
 require recipes-kernel/linux/linux-yocto.inc
 
 SRC_URI = "git://git@github.com/sifive/riscv-linux.git;protocol=ssh;name=machine;branch=${KBRANCH} \
-           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=${KMETA}"
+           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=${KMETA}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-LINUX_VERSION ?= "6.6.77"
+LINUX_VERSION ?= "6.12.33"
 LINUX_VERSION_EXTENSION = ""
 
 PV = "${LINUX_VERSION}+git${SRCPV}"


### PR DESCRIPTION
Kernel upgrade to 6.12
Trap and emulate SENVCFG and HENVCFG in OpenSBI